### PR TITLE
Enable subquery support in WHERE expression

### DIFF
--- a/src/PHPSQLParser/builders/WhereBracketExpressionBuilder.php
+++ b/src/PHPSQLParser/builders/WhereBracketExpressionBuilder.php
@@ -53,6 +53,11 @@ use PHPSQLParser\utils\ExpressionType;
  */
 class WhereBracketExpressionBuilder implements Builder {
 
+    protected function buildSubQuery($parsed) {
+        $builder = new SubQueryBuilder();
+        return $builder->build($parsed);
+    }
+
     protected function buildColRef($parsed) {
         $builder = new ColumnReferenceBuilder();
         return $builder->build($parsed);
@@ -109,6 +114,7 @@ class WhereBracketExpressionBuilder implements Builder {
             $sql .= $this->build($v);
             $sql .= $this->buildUserVariable($v);
             $sql .= $this->buildReserved($v);
+            $sql .= $this->buildSubQuery($v);
             
             if ($len == strlen($sql)) {
                 throw new UnableToCreateSQLException('WHERE expression subtree', $k, $v, 'expr_type');


### PR DESCRIPTION
The use of a subquery in a WHERE bracket expression was not correctly handled by the parser:

SELECT
  myField
FROM
  myTable
WHERE
filterField IN (
  SELECT
    otherField
  FROM
    otherTable
)